### PR TITLE
Implement gRPC and SS WS protocols for Xray

### DIFF
--- a/install/xray.sh
+++ b/install/xray.sh
@@ -51,7 +51,7 @@ mkdir -p /etc/xray
   --fullchain-file /etc/xray/cert.crt \
   --ecc
 
-# Deploy config.json ke xray (vmess, vless, trojan)
+# Deploy config.json ke xray (vmess, vless, trojan, ss-ws)
 cat > /etc/xray/config.json <<EOF
 {
   "log": {
@@ -62,6 +62,7 @@ cat > /etc/xray/config.json <<EOF
   "inbounds": [
     {
       "port": 443,
+      "listen": "0.0.0.0",
       "protocol": "vmess",
       "settings": {
         "clients": []
@@ -85,6 +86,7 @@ cat > /etc/xray/config.json <<EOF
     },
     {
       "port": 80,
+      "listen": "0.0.0.0",
       "protocol": "vmess",
       "settings": {
         "clients": []
@@ -99,7 +101,32 @@ cat > /etc/xray/config.json <<EOF
       "tag": "vmess-nontls"
     },
     {
-      "port": 443,
+      "port": 4443,
+      "listen": "0.0.0.0",
+      "protocol": "vmess",
+      "settings": {
+        "clients": []
+      },
+      "streamSettings": {
+        "network": "grpc",
+        "security": "tls",
+        "tlsSettings": {
+          "certificates": [
+            {
+              "certificateFile": "/etc/xray/cert.crt",
+              "keyFile": "/etc/xray/private.key"
+            }
+          ]
+        },
+        "grpcSettings": {
+          "serviceName": "vmess-grpc"
+        }
+      },
+      "tag": "vmess-grpc"
+    },
+    {
+      "port": 8443,
+      "listen": "0.0.0.0",
       "protocol": "vless",
       "settings": {
         "clients": [],
@@ -123,7 +150,8 @@ cat > /etc/xray/config.json <<EOF
       "tag": "vless-tls"
     },
     {
-      "port": 80,
+      "port": 8080,
+      "listen": "0.0.0.0",
       "protocol": "vless",
       "settings": {
         "clients": [],
@@ -139,7 +167,33 @@ cat > /etc/xray/config.json <<EOF
       "tag": "vless-nontls"
     },
     {
-      "port": 443,
+      "port": 8444,
+      "listen": "0.0.0.0",
+      "protocol": "vless",
+      "settings": {
+        "clients": [],
+        "decryption": "none"
+      },
+      "streamSettings": {
+        "network": "grpc",
+        "security": "tls",
+        "tlsSettings": {
+          "certificates": [
+            {
+              "certificateFile": "/etc/xray/cert.crt",
+              "keyFile": "/etc/xray/private.key"
+            }
+          ]
+        },
+        "grpcSettings": {
+          "serviceName": "vless-grpc"
+        }
+      },
+      "tag": "vless-grpc"
+    },
+    {
+      "port": 2083,
+      "listen": "0.0.0.0",
       "protocol": "trojan",
       "settings": {
         "clients": []
@@ -160,6 +214,76 @@ cat > /etc/xray/config.json <<EOF
         }
       },
       "tag": "trojan-tls"
+    },
+    {
+      "port": 2084,
+      "listen": "0.0.0.0",
+      "protocol": "trojan",
+      "settings": {
+        "clients": []
+      },
+      "streamSettings": {
+        "network": "grpc",
+        "security": "tls",
+        "tlsSettings": {
+          "certificates": [
+            {
+              "certificateFile": "/etc/xray/cert.crt",
+              "keyFile": "/etc/xray/private.key"
+            }
+          ]
+        },
+        "grpcSettings": {
+          "serviceName": "trojan-grpc"
+        }
+      },
+      "tag": "trojan-grpc"
+    },
+    {
+      "port": 9443,
+      "listen": "0.0.0.0",
+      "protocol": "shadowsocks",
+      "settings": {
+        "method": "aes-128-gcm",
+        "clients": [
+          #ssws
+        ]
+      },
+      "streamSettings": {
+        "network": "ws",
+        "security": "tls",
+        "tlsSettings": {
+          "certificates": [
+            {
+              "certificateFile": "/etc/xray/cert.crt",
+              "keyFile": "/etc/xray/private.key"
+            }
+          ]
+        },
+        "wsSettings": {
+          "path": "/ss-ws"
+        }
+      },
+      "tag": "ssws-tls"
+    },
+    {
+      "port": 9080,
+      "listen": "0.0.0.0",
+      "protocol": "shadowsocks",
+      "settings": {
+        "method": "aes-128-gcm",
+        "clients": [
+          #ssws
+        ]
+      },
+      "streamSettings": {
+        "network": "ws",
+        "security": "none",
+        "wsSettings": {
+          "path": "/ss-ws"
+        }
+      },
+      "tag": "ssws-nontls"
     }
   ],
   "outbounds": [
@@ -197,9 +321,19 @@ EOF
 systemctl daemon-reload
 systemctl enable xray
 
-# Tambahkan info ke log install
-grep -q "XRAY TLS" /root/log-install.txt || echo "XRAY TLS         : 443" >> /root/log-install.txt
-grep -q "XRAY None TLS" /root/log-install.txt || echo "XRAY None TLS    : 80" >> /root/log-install.txt
+# Tambahkan info ke log install (setiap protocol port unik)
+cat > /root/log-install.txt <<'LOGEOF'
+XRAY VMess TLS      : 443
+XRAY VMess None TLS : 80
+XRAY VMess gRPC     : 4443
+XRAY VLESS TLS      : 8443
+XRAY VLESS None TLS : 8080
+XRAY VLESS gRPC     : 8444
+XRAY Trojan TLS     : 2083
+XRAY Trojan gRPC    : 2084
+XRAY SS WS TLS      : 9443
+XRAY SS WS none TLS : 9080
+LOGEOF
 
 # Output final
 echo -e "${GREEN}✅ Xray-core berhasil di-install dan dikonfigurasi!${NC}"

--- a/xray/add-ssws.sh
+++ b/xray/add-ssws.sh
@@ -9,15 +9,15 @@ else
   domain=$IP
 fi
 
-port_tls=$(cat ~/log-install.txt | grep -w "Shadowsocks WS TLS" | cut -d: -f2 | sed 's/ //g')
-port_none=$(cat ~/log-install.txt | grep -w "Shadowsocks WS none TLS" | cut -d: -f2 | sed 's/ //g')
+port_tls=$(cat ~/log-install.txt | grep -w "XRAY SS WS TLS" | cut -d: -f2 | sed 's/ //g')
+port_none=$(cat ~/log-install.txt | grep -w "XRAY SS WS none TLS" | cut -d: -f2 | sed 's/ //g')
 
 until [[ $user =~ ^[a-zA-Z0-9_]+$ && ${CLIENT_EXISTS} == '0' ]]; do
   echo -e "\033[0;34m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m"
   echo -e "\E[44;1;39m     Add Shadowsocks Account     \E[0m"
   echo -e "\033[0;34m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m"
   read -rp "User: " -e user
-  CLIENT_EXISTS=$(grep -w $user /etc/xray/config.json | wc -l)
+  CLIENT_EXISTS=$(grep -w "\"$user\"" /etc/xray/config.json | wc -l)
 
   if [[ ${CLIENT_EXISTS} == '1' ]]; then
     clear
@@ -37,7 +37,8 @@ uuid=$(cat /proc/sys/kernel/random/uuid)
 read -p "Expired (days): " masaaktif
 exp=$(date -d "$masaaktif days" +"%Y-%m-%d")
 
-sed -i '/#ssws$/a\#& '"$user $exp"'\n},{"password": "'"$uuid"'", "method": "'"$cipher"'", "email": "'"$user"'"' /etc/xray/config.json
+# inject user ke config SS WS (marker: #ssws)
+sed -i 's/#ssws$/#ssws\n#ssws '"$user $exp"'\n    },{"password": "'"$uuid"'", "method": "'"$cipher"'", "email": "'"$user"'"\n#ssws/' /etc/xray/config.json
 
 sslink1="ss://$(echo -n "$cipher:$uuid" | base64 -w0)@$domain:$port_tls?plugin=xray-plugin;path=/ss-ws;host=$domain;tls#${user}"
 sslink2="ss://$(echo -n "$cipher:$uuid" | base64 -w0)@$domain:$port_none?plugin=xray-plugin;path=/ss-ws;host=$domain#${user}"

--- a/xray/add-trojan.sh
+++ b/xray/add-trojan.sh
@@ -8,8 +8,9 @@ echo -e "\033[0;34m━━━━━━━━━━━━━━━━━━━━�
 # ambil domain
 domain=$(cat /etc/xray/domain)
 
-# ambil port TLS
-tls=$(grep -w "XRAY TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
+# ambil port dari log install (format baru)
+tls=$(grep -w "XRAY Trojan TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
+grpc=$(grep -w "XRAY Trojan gRPC" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
 
 read -rp "Username : " user
 read -rp "Expired (days): " masaaktif
@@ -19,18 +20,23 @@ exp=$(date -d "$masaaktif days" +"%Y-%m-%d")
 
 CONFIG="/etc/xray/config.json"
 
-# inject user ke config
+# inject user ke config (ws tls, grpc)
 jq --arg uuid "$uuid" --arg user "$user" '
 (.inbounds[] | select(.tag=="trojan-tls").settings.clients) +=
+[{"password":$uuid,"email":$user}] |
+(.inbounds[] | select(.tag=="trojan-grpc").settings.clients) +=
 [{"password":$uuid,"email":$user}]
 ' $CONFIG > /tmp/config.json
 
 mv /tmp/config.json $CONFIG
 
-# generate trojan link
-trojanlink1="trojan://${uuid}@${domain}:${tls}?path=/trojan&security=tls&type=ws#${user}"
+# tambahkan comment expiry untuk tracking renew
+sed -i '/"tag": "trojan-tls"/i \  #trojan '"$user $exp" $CONFIG
 
-trojanlink2="trojan://${uuid}@${domain}:${tls}?mode=gun&security=tls&type=grpc&serviceName=trojan-grpc&sni=bug.com#${user}"
+# generate trojan link
+trojanlink1="trojan://${uuid}@${domain}:${tls}?path=/trojan&security=tls&type=ws&sni=${domain}#${user}"
+
+trojanlink2="trojan://${uuid}@${domain}:${grpc}?mode=gun&security=tls&type=grpc&serviceName=trojan-grpc&sni=${domain}#${user}"
 
 systemctl restart xray
 
@@ -41,6 +47,7 @@ echo -e "\033[0;34m━━━━━━━━━━━━━━━━━━━━�
 echo -e "Remarks        : ${user}" | tee -a /etc/log-create-trojan.log
 echo -e "Domain         : ${domain}" | tee -a /etc/log-create-trojan.log
 echo -e "Port TLS       : ${tls}" | tee -a /etc/log-create-trojan.log
+echo -e "Port gRPC      : ${grpc}" | tee -a /etc/log-create-trojan.log
 echo -e "Password       : ${uuid}" | tee -a /etc/log-create-trojan.log
 echo -e "Network        : ws / grpc" | tee -a /etc/log-create-trojan.log
 echo -e "Path           : /trojan" | tee -a /etc/log-create-trojan.log

--- a/xray/add-vless.sh
+++ b/xray/add-vless.sh
@@ -8,9 +8,10 @@ echo -e "\033[0;34m━━━━━━━━━━━━━━━━━━━━�
 # ambil domain
 domain=$(cat /etc/xray/domain)
 
-# ambil port dari log install
-tls=$(grep -w "XRAY TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
-none=$(grep -w "XRAY None TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
+# ambil port dari log install (format baru)
+tls=$(grep -w "XRAY VLESS TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
+none=$(grep -w "XRAY VLESS None TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
+grpc=$(grep -w "XRAY VLESS gRPC" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
 
 read -rp "Username : " user
 read -rp "Expired (days): " masaaktif
@@ -18,22 +19,27 @@ read -rp "Expired (days): " masaaktif
 uuid=$(cat /proc/sys/kernel/random/uuid)
 exp=$(date -d "$masaaktif days" +"%Y-%m-%d")
 
-# inject user ke config
+# inject user ke config (ws tls, ws nontls, grpc)
 jq --arg uuid "$uuid" --arg user "$user" '
 (.inbounds[] | select(.tag=="vless-tls").settings.clients) +=
 [{"id":$uuid,"email":$user}] |
 (.inbounds[] | select(.tag=="vless-nontls").settings.clients) +=
+[{"id":$uuid,"email":$user}] |
+(.inbounds[] | select(.tag=="vless-grpc").settings.clients) +=
 [{"id":$uuid,"email":$user}]
 ' /etc/xray/config.json > /tmp/config.json
 
 mv /tmp/config.json /etc/xray/config.json
 
+# tambahkan comment expiry untuk tracking renew
+sed -i '/"tag": "vless-tls"/i \  #vless '"$user $exp" /etc/xray/config.json
+
 # generate vless link
-vlesslink1="vless://${uuid}@${domain}:${tls}?path=/vless&security=tls&encryption=none&type=ws#${user}"
+vlesslink1="vless://${uuid}@${domain}:${tls}?path=/vless&security=tls&encryption=none&type=ws&sni=${domain}#${user}"
 
 vlesslink2="vless://${uuid}@${domain}:${none}?path=/vless&encryption=none&type=ws#${user}"
 
-vlesslink3="vless://${uuid}@${domain}:${tls}?mode=gun&security=tls&encryption=none&type=grpc&serviceName=vless-grpc&sni=bug.com#${user}"
+vlesslink3="vless://${uuid}@${domain}:${grpc}?mode=gun&security=tls&encryption=none&type=grpc&serviceName=vless-grpc&sni=${domain}#${user}"
 
 systemctl restart xray
 
@@ -46,7 +52,7 @@ echo -e "Domain         : ${domain}" | tee -a /etc/log-create-vless.log
 echo -e "Wildcard       : (bug.com).${domain}" | tee -a /etc/log-create-vless.log
 echo -e "Port TLS       : ${tls}" | tee -a /etc/log-create-vless.log
 echo -e "Port none TLS  : ${none}" | tee -a /etc/log-create-vless.log
-echo -e "Port gRPC      : ${tls}" | tee -a /etc/log-create-vless.log
+echo -e "Port gRPC      : ${grpc}" | tee -a /etc/log-create-vless.log
 echo -e "id             : ${uuid}" | tee -a /etc/log-create-vless.log
 echo -e "Encryption     : none" | tee -a /etc/log-create-vless.log
 echo -e "Network        : ws / grpc" | tee -a /etc/log-create-vless.log

--- a/xray/add-vmess.sh
+++ b/xray/add-vmess.sh
@@ -8,9 +8,10 @@ echo -e "\033[0;34m━━━━━━━━━━━━━━━━━━━━�
 # ambil domain
 domain=$(cat /etc/xray/domain)
 
-# ambil port dari log install
-tls=$(grep -w "XRAY TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
-none=$(grep -w "XRAY None TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
+# ambil port dari log install (format baru)
+tls=$(grep -w "XRAY VMess TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
+none=$(grep -w "XRAY VMess None TLS" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
+grpc=$(grep -w "XRAY VMess gRPC" /root/log-install.txt | cut -d: -f2 | tr -d ' ')
 
 read -rp "Username : " user
 read -rp "Expired (days): " masaaktif
@@ -18,22 +19,27 @@ read -rp "Expired (days): " masaaktif
 uuid=$(cat /proc/sys/kernel/random/uuid)
 exp=$(date -d "$masaaktif days" +"%Y-%m-%d")
 
-# inject user ke config
+# inject user ke config (ws tls, ws nontls, grpc)
 jq --arg uuid "$uuid" --arg user "$user" '
 (.inbounds[] | select(.tag=="vmess-tls").settings.clients) +=
 [{"id":$uuid,"alterId":0,"email":$user}] |
 (.inbounds[] | select(.tag=="vmess-nontls").settings.clients) +=
+[{"id":$uuid,"alterId":0,"email":$user}] |
+(.inbounds[] | select(.tag=="vmess-grpc").settings.clients) +=
 [{"id":$uuid,"alterId":0,"email":$user}]
 ' /etc/xray/config.json > /tmp/config.json
 
 mv /tmp/config.json /etc/xray/config.json
+
+# tambahkan comment expiry untuk tracking renew
+sed -i '/"tag": "vmess-tls"/i \  #vmess '"$user $exp" /etc/xray/config.json
 
 # generate vmess link
 vmesslink1="vmess://$(echo -n "{\"v\":\"2\",\"ps\":\"${user}\",\"add\":\"${domain}\",\"port\":\"${tls}\",\"id\":\"${uuid}\",\"aid\":\"0\",\"net\":\"ws\",\"path\":\"/vmess\",\"type\":\"none\",\"host\":\"${domain}\",\"tls\":\"tls\"}" | base64 -w 0)"
 
 vmesslink2="vmess://$(echo -n "{\"v\":\"2\",\"ps\":\"${user}\",\"add\":\"${domain}\",\"port\":\"${none}\",\"id\":\"${uuid}\",\"aid\":\"0\",\"net\":\"ws\",\"path\":\"/vmess\",\"type\":\"none\",\"host\":\"${domain}\",\"tls\":\"none\"}" | base64 -w 0)"
 
-vmesslink3="vmess://${uuid}@${domain}:${tls}?mode=gun&security=tls&type=grpc&serviceName=vmess-grpc&sni=bug.com#${user}"
+vmesslink3="vmess://${uuid}@${domain}:${grpc}?mode=gun&security=tls&type=grpc&serviceName=vmess-grpc&sni=${domain}#${user}"
 
 systemctl restart xray
 
@@ -46,7 +52,7 @@ echo -e "Domain         : ${domain}" | tee -a /etc/log-create-vmess.log
 echo -e "Wildcard       : (bug.com).${domain}" | tee -a /etc/log-create-vmess.log
 echo -e "Port TLS       : ${tls}" | tee -a /etc/log-create-vmess.log
 echo -e "Port none TLS  : ${none}" | tee -a /etc/log-create-vmess.log
-echo -e "Port gRPC      : ${tls}" | tee -a /etc/log-create-vmess.log
+echo -e "Port gRPC      : ${grpc}" | tee -a /etc/log-create-vmess.log
 echo -e "id             : ${uuid}" | tee -a /etc/log-create-vmess.log
 echo -e "Alter ID       : 0" | tee -a /etc/log-create-vmess.log
 echo -e "Encryption     : auto" | tee -a /etc/log-create-vmess.log

--- a/xray/del-trojan.sh
+++ b/xray/del-trojan.sh
@@ -46,6 +46,9 @@ map(select(.email != $user))
 
 mv /tmp/config.json $CONFIG
 
+# hapus comment expiry
+sed -i "/#trojan $user/d" $CONFIG
+
 systemctl restart xray
 
 echo ""

--- a/xray/del-vless.sh
+++ b/xray/del-vless.sh
@@ -48,6 +48,9 @@ map(select(.email != $user))
 
 mv /tmp/config.json $CONFIG
 
+# hapus comment expiry
+sed -i "/#vless $user/d" $CONFIG
+
 systemctl restart xray
 
 echo ""

--- a/xray/del-vmess.sh
+++ b/xray/del-vmess.sh
@@ -48,6 +48,9 @@ map(select(.email != $user))
 
 mv /tmp/config.json $CONFIG
 
+# hapus comment expiry
+sed -i "/#vmess $user/d" $CONFIG
+
 systemctl restart xray
 
 echo ""


### PR DESCRIPTION
Add gRPC inbounds for VMess, VLESS, and Trojan. Introduce Shadowsocks WS protocol with TLS and non-TLS options.

Update `log-install.txt` to reflect all protocol-specific ports. Add expiry tracking comments for users in `config.json`. Standardize `listen`
address to `0.0.0.0` for all inbounds and adjust several port numbers. Improve SNI in generated links and client existence checks.

gRPC+ SS WS is now implemented, thanks to @AgungBahtiarr